### PR TITLE
feat: dependabot.yaml template

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,7 @@
+# Templates
+
+Assortment of templates of files.
+
+## `dependabot.yaml`
+
+[🔍 Repositories using this template](https://github.com/search?q=-is:archived+path:.github/dependabot.y*ml+"https://github.com/verkstedt/.github/blob/main/templates/dependabot.yaml"&type=code)

--- a/templates/dependabot.yaml
+++ b/templates/dependabot.yaml
@@ -3,8 +3,9 @@
 # This file has been created from
 # https://github.com/verkstedt/.github/blob/main/templates/dependabot.yaml
 #
-# IMPORTANT: Dependabot should be configured to create PRs for security
-# updates in the project settings on GitHub.
+# IMPORTANT: This does not affect creation of PRs with security updates.
+# That is configured on GitHub settings and should be done on the
+# organization level, if possible.
 #
 # IF YOU MODIFY IT IN ANY WAY, DESCRIBE IT IN THE COMMENT HERE
 # to make updating in the future easier.

--- a/templates/dependabot.yaml
+++ b/templates/dependabot.yaml
@@ -1,0 +1,32 @@
+# Default dependabot configuration
+#
+# This file has been created from
+# https://github.com/verkstedt/.github/blob/main/templates/dependabot.yaml
+#
+# IMPORTANT: Dependabot should be configured to create PRs for security
+# updates in the project settings on GitHub.
+#
+# IF YOU MODIFY IT IN ANY WAY, DESCRIBE IT IN THE COMMENT HERE
+# to make updating in the future easier.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "quarterly"
+      time: "12:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "quarterly"
+      time: "12:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Why?

Template to promote more consistent config across projects.

Will follow with a PR adding support for this in [@verkstedt/setup-repo](https://www.npmjs.com/package/@verkstedt/setup-repo).

Closes https://verkstedt.atlassian.net/browse/VIP-98
