### PR TITLE
fix(workflows templates): Failure conditions

### DIFF
--- a/workflow-templates/chromatic.yaml
+++ b/workflow-templates/chromatic.yaml
@@ -23,7 +23,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -38,6 +38,6 @@ jobs:
     name: Notify about failure on main branch
     needs:
       - chromatic
-    if: failure() && github.ref == 'refs/heads/main'
+    if: failure() && ( github.head_ref || github.ref_name ) == 'main'
     uses: verkstedt/actions/.github/workflows/notify-main-branch-failure.yaml@v1
     secrets: inherit

--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -16,8 +16,6 @@ on:
     branches:
       - main
   pull_request:
-    branches-ignore:
-      - main
     types:
       - opened
       - reopened

--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -23,7 +23,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -57,6 +57,6 @@ jobs:
       - ci
       # If you add any new jobs, also add them here:
       #- lint-something-else
-    if: failure() && ( github.head_ref || github.ref_name ) == 'main'
+    if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: verkstedt/actions/.github/workflows/notify-main-branch-failure.yaml@v1
     secrets: inherit

--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -23,7 +23,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -57,6 +57,6 @@ jobs:
       - ci
       # If you add any new jobs, also add them here:
       #- lint-something-else
-    if: failure() && github.head_ref == 'main'
+    if: failure() && ( github.head_ref || github.ref_name ) == 'main'
     uses: verkstedt/actions/.github/workflows/notify-main-branch-failure.yaml@v1
     secrets: inherit

--- a/workflow-templates/ci.yaml
+++ b/workflow-templates/ci.yaml
@@ -16,6 +16,8 @@ on:
     branches:
       - main
   pull_request:
+    branches-ignore:
+      - main
     types:
       - opened
       - reopened


### PR DESCRIPTION
Two of the workflow templates had steps that were to be executed when
previous steps failed. `ci` had an error where it compared
`github.head_ref` to `main`, but `head_ref` takes the value of
`refs/heads/main`.

This commit also aligns compared value with workflows concurrency, since
in theory push event to `main` could be cancelled by a PR where the head
branch is `main`.

## Next steps

- [ ] Update [:mag: repos using these templates](https://github.com/search?q=org%3Averkstedt++%28+path%3A.github%2Fworkflows%2Fci.yaml+https%3A%2F%2Fgithub.com%2Fverkstedt%2F.github%2Fblob%2Fmain%2Fworkflow-templates%2Fci.yaml+%22if%3A+failure%28%29+%26%26+github.ref+%3D%3D+%27refs%2Fheads%2Fmain%27%22+%29+OR+%28+path%3A.github%2Fworkflows%2Fchromatic.yaml+https%3A%2F%2Fgithub.com%2Fverkstedt%2F.github%2Fblob%2Fmain%2Fworkflow-templates%2Fchromatic.yaml+%22if%3A+failure%28%29+%26%26+github.ref+%3D%3D+%27refs%2Fheads%2Fmain%27%22+%29&type=code)


---


## `ref` vs `ref_name` vs `head_ref`

For anybody interested:

```
github.event_name = push
github.ref ...... = refs/heads/main
github.ref_name . = main
github.head_ref . = 

github.event_name = pull_request_target
github.ref ...... = refs/heads/main
github.ref_name . = main
github.head_ref . = pr

github.event_name = pull_request
github.ref ...... = refs/pull/1/merge
github.ref_name . = 1/merge
github.head_ref . = pr
```